### PR TITLE
Describing the default output folder in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Or install it yourself as:
 
 ## Usage
 
+The default output folder for the images is `doc/state_machines`.
+
 #### Examples
 
 To generate a graph for a specific file / class:


### PR DESCRIPTION
The "original" of this rake task generated `png` files in the `pwd`. This gem generates them to `doc/state_machines`. It should be made clear in the README.