### PR TITLE
chore: test Ruby 3.4 and 4.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.4', '4.0']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/lib/state_machines/graphviz/graph.rb
+++ b/lib/state_machines/graphviz/graph.rb
@@ -25,7 +25,7 @@ module StateMachines
     #   "landscape").  Default is "portrait".
     def initialize(name, options = {})
       options = { path: 'doc/state_machines', format: 'png', font: 'Arial', orientation: 'portrait' }.merge(options)
-      options.assert_valid_keys(:path, :format, :font, :orientation)
+      StateMachines::OptionsValidator.assert_valid_keys!(options, :path, :format, :font, :orientation)
 
       # TODO: fail if path cannot be created or readonly
       FileUtils.mkpath(options[:path]) unless Dir.exist? options[:path]

--- a/state_machines-graphviz.gemspec
+++ b/state_machines-graphviz.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ruby-graphviz'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'minitest', '>=5.6.0'
+  spec.add_development_dependency 'minitest', '= 5.27.0'
 end


### PR DESCRIPTION
Update CI matrix to test Ruby 3.4 and 4.0 only.